### PR TITLE
[1.x] Publish config.

### DIFF
--- a/src/PaymentServiceProvider.php
+++ b/src/PaymentServiceProvider.php
@@ -24,6 +24,10 @@ class PaymentServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__ . '/database/migrations/2021_01_01_000000_create_base_payment_tables.php' => database_path('migrations/' . now()->format('Y_m_d_His') . '_create_base_payment_tables.php'),
         ], 'migrations');
+
+        $this->publishes([
+            __DIR__ . '/stubs/config-publish.stub' => config_path('payment.php'),
+        ], 'config');
     }
 
     public function register()

--- a/src/config/payment.php
+++ b/src/config/payment.php
@@ -9,7 +9,7 @@ return [
     |
     | When set to true, it will pass the provider & merchant into the testing
     | gateway so you can mock your requests as you wish. This is very
-    | usefull when you are running tests in a CI/CD environment.
+    | useful when you are running tests in a CI/CD environment.
     |
     */
     'test_mode' => false,

--- a/src/stubs/config-publish.stub
+++ b/src/stubs/config-publish.stub
@@ -1,0 +1,76 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Payment Defaults
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default payment "provider" for your application.
+    | You may set these defaults as required, you should set your primary payments
+    | provider here, as it will be the provider to be injected automatically.
+    |
+    */
+    'defaults' => [
+        'driver' => 'config',
+        'provider' => '...',
+        'merchant' => '...',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Payment Test Mode
+    |--------------------------------------------------------------------------
+    |
+    | When set to true, it will pass the provider & merchant into the testing
+    | gateway so you can mock your requests as you wish. This is very
+    | useful when you are running tests in a CI/CD environment.
+    |
+    */
+    'test_mode' => env('PAYMENT_TEST_MODE', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Payment Provider Configurations
+    |--------------------------------------------------------------------------
+    |
+    | Here you may provide the location of your provider's gateway implementation
+    | by specifying the 'gateway' key for each provider and mapping the class to
+    | it, you may also add any provider specific configuration you might have.
+    |
+    */
+    'providers' => [
+        // ...
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Payment Merchants
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify all the merchants that will be supported by this application
+    | to process payments for, along with any configuration needed in order to do so.
+    | e.g. You may provide each merchant's api keys and endpoints.
+    |
+    */
+    'merchants' => [
+        // ...
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Payment Models
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to override the models to be used for managing payments.
+    | You may define your own models that extend the ones of the package in order to
+    | keep your relationships in sync with your own models.
+    |
+    */
+    // 'models' => [
+    //     \Payavel\Checkout\Models\PaymentMethod::class => \App\Models\Payment\PaymentMethod::class,
+    //     \Payavel\Checkout\Models\Wallet::class => \App\Models\Payment\Wallet::class,
+    // ],
+
+];


### PR DESCRIPTION
### **What does this PR do?** :robot:
Publishes the `payment.php` config file under the 'config' tag.

### **How should this be tested?** :microscope:
You may run the `php artisan vendor:publish --provider='Payavel\Checkout\PaymentServiceProvider' --tag=config` and make sure the config/payment.php file magically appeared.

### **Does this relate to any issue?** :link:
Closes #3 
