### PR TITLE
[2.x] Config driver 'is_default' deprecation.

### DIFF
--- a/src/DataTransferObjects/Merchant.php
+++ b/src/DataTransferObjects/Merchant.php
@@ -30,7 +30,7 @@ class Merchant implements Merchantable
                 );
             }
 
-            return config('payment.providers.' . $provider);
+            return array_merge(['id' => $provider], config('payment.providers.' . $provider));
         });
     }
 

--- a/src/Drivers/ConfigDriver.php
+++ b/src/Drivers/ConfigDriver.php
@@ -56,22 +56,22 @@ class ConfigDriver extends PaymentServiceDriver
      * Get the default providable identifier.
      *
      * @param \Payavel\Checkout\Contracts\Merchantable|null $merchant
-     * @return string|int
+     * @return string|int|\Payavel\Checkout\Contracts\Providable
      */
     public function getDefaultProvider(Merchantable $merchant = null)
     {
         if (
             ! $merchant instanceof Merchant ||
-            is_null($provider = $merchant->providers->search(function ($provider) { return $provider['is_default'] ?? false; }))
+            is_null($provider = $merchant->providers->first())
         ) {
             return parent::getDefaultProvider();
         }
 
-        return config('payment.providers.' . $provider . '.id');
+        return $provider['id'];
     }
 
     /**
-     * Resolve the merchantable intance.
+     * Resolve the merchantable instance.
      *
      * @param \Payavel\Checkout\Contracts\Merchantable|string $merchant
      * @return \Payavel\Checkout\Contracts\Merchantable|null

--- a/tests/GatewayTestCase.php
+++ b/tests/GatewayTestCase.php
@@ -79,10 +79,8 @@ abstract class GatewayTestCase extends TestCase
                 'alternate' => [
                     'name' => 'Alternate',
                     'providers' => [
-                        'alternative' => [
-                            'is_default' => true,
-                        ],
-                        $this->provider => [],
+                        'alternative',
+                        $this->provider,
                     ],
                 ],
             ],

--- a/tests/GatewayTestCase.php
+++ b/tests/GatewayTestCase.php
@@ -73,9 +73,7 @@ abstract class GatewayTestCase extends TestCase
                 $this->merchant => [
                     'name' => Str::headline($this->merchant),
                     'providers' => [
-                        $this->provider => [
-                            'is_default' => true,
-                        ],
+                        $this->provider,
                     ],
                 ],
                 'alternate' => [


### PR DESCRIPTION
### **What does this PR do?** :robot:
Parts of the package use the first listed provider for the merchant as the default, while the config driver was still looking for the 'is_default' key to determine the default provider.

This PR fixes that issue ☝🏼.

### **Any background context you would like to provide?** :construction:
I am pointing this at `2.x` because it could be a breaking change for some people who had adapted to this bug.

### **Does this relate to any issue?** :link:
Closes #13 
