### PR TITLE
[1.x] Add `setUp()` to response.

### DIFF
--- a/src/PaymentResponse.php
+++ b/src/PaymentResponse.php
@@ -93,6 +93,18 @@ abstract class PaymentResponse implements PaymentResponder
     {
         $this->rawResponse = $rawResponse;
         $this->additionalInformation = $additionalInformation;
+
+        $this->setUp();
+    }
+
+    /**
+     * Set up the response.
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        //
     }
 
     /**

--- a/src/stubs/payment-response.stub
+++ b/src/stubs/payment-response.stub
@@ -7,6 +7,16 @@ use Payavel\Checkout\PaymentResponse;
 class {{ name }}PaymentResponse extends PaymentResponse
 {
     /**
+     * Set up the response.
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        //
+    }
+
+    /**
      * Determines the status code based on the request's raw response.
      *
      * @return int


### PR DESCRIPTION
### **What does this PR do?** :robot:
Similar to the `PaymentRequest::class`, now we have a `setUp()` function in the `PaymentResponse::class` that is called in the `__construct()` method.

### **Does this relate to any issue?** :link:
Closes #22 
