### PR TITLE
[2.x] Load default migrations for this package if DX decides not to publish/modify them.

### DIFF
--- a/src/Console/Commands/Install.php
+++ b/src/Console/Commands/Install.php
@@ -53,10 +53,6 @@ class Install extends Command
      */
     public function handle()
     {
-        if (! class_exists('CreateBasePaymentTables')) {
-            $this->call('vendor:publish', ['--provider' => 'Payavel\Checkout\PaymentServiceProvider', '--tag' => 'payavel-migrations']);
-        }
-
         $this->installProviders();
 
         $this->installMerchants();

--- a/src/PaymentServiceProvider.php
+++ b/src/PaymentServiceProvider.php
@@ -10,9 +10,15 @@ class PaymentServiceProvider extends ServiceProvider
 {
     public function boot()
     {
+        if (! $this->app->runningInConsole()) {
+            return;
+        }
+
         $this->registerPublishableAssets();
 
         $this->registerCommands();
+
+        $this->registerMigrations();
     }
 
     public function register()
@@ -29,10 +35,6 @@ class PaymentServiceProvider extends ServiceProvider
 
     protected function registerPublishableAssets()
     {
-        if (! $this->app->runningInConsole()) {
-            return;
-        }
-
         $this->publishes([
             __DIR__ . '/database/migrations/2021_01_01_000000_create_base_payment_tables.php' => database_path('migrations/2021_01_01_000000_create_base_payment_tables.php'),
         ], 'payavel-migrations');
@@ -44,13 +46,14 @@ class PaymentServiceProvider extends ServiceProvider
 
     protected function registerCommands()
     {
-        if (! $this->app->runningInConsole()) {
-            return;
-        }
-
         $this->commands([
             MakeProvider::class,
             Install::class,
         ]);
+    }
+
+    protected function registerMigrations()
+    {
+        $this->loadMigrationsFrom(__DIR__ . '/database/migrations');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -33,20 +33,6 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     }
 
     /**
-     * Perform any work that should take place once the database has finished refreshing.
-     *
-     * @return void
-     */
-    protected function afterRefreshingDatabase()
-    {
-        if (! class_exists('CreateBasePaymentTables')) {
-            $this->artisan('vendor:publish', ['--provider' => 'Payavel\Checkout\PaymentServiceProvider', '--tag' => 'payavel-migrations']);
-
-            $this->artisan('migrate');
-        }
-    }
-
-    /**
      * Setup the test environment.
      *
      * @return void

--- a/tests/Unit/BillableTraitTest.php
+++ b/tests/Unit/BillableTraitTest.php
@@ -9,23 +9,6 @@ use Payavel\Checkout\Tests\User;
 
 class BillableTraitTest extends TestCase
 {
-    /**
-     * Setup the test environment.
-     *
-     * @return void
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->artisan('vendor:publish', [
-            '--provider' => 'Payavel\\Checkout\\PaymentServiceProvider',
-            '--tag' => 'payavel-migrations'
-        ]);
-
-        $this->artisan('migrate');
-    }
-
     /** @test */
     public function retrieve_billable_wallets()
     {


### PR DESCRIPTION
### **What does this PR do?** :robot:
- `loadMigrationsFrom()` automatically if DX does not feel the need to make any modifications.
- Remove legacy workaround code that used to publish the migration.

### **Does this relate to any issue?** :link:
Closes #25 
