### PR TITLE
[1.x] Add ability to `reset()` payment service.

### DIFF
--- a/src/Facades/Payment.php
+++ b/src/Facades/Payment.php
@@ -13,6 +13,7 @@ use Payavel\Checkout\PaymentGateway;
  * @method static \Payavel\Checkout\PaymentGateway merchant($merchant)
  * @method static \Payavel\Checkout\Contracts\Merchantable getMerchant()
  * @method static void setMerchant($merchant, $strict = true)
+ * @method static void reset()
  * @method static string|int|\Payavel\Checkout\Contracts\Merchantable getDefaultMerchant()
  * @method static \Payavel\Checkout\PaymentResponse getWallet(\Payavel\Checkout\Models\Wallet $wallet)
  * @method static \Payavel\Checkout\PaymentResponse getPaymentMethod(\Payavel\Checkout\Models\PaymentMethod $paymentMethod)

--- a/src/PaymentService.php
+++ b/src/PaymentService.php
@@ -205,4 +205,16 @@ class PaymentService
 
         $this->gateway = new $gateway($provider, $merchant);
     }
+
+    /**
+     * Reset the payment service to it's defaults.
+     *
+     * @return void
+     */
+    public function reset()
+    {
+        $this->provider = null;
+        $this->merchant = null;
+        $this->gateway = null;
+    }
 }

--- a/tests/GatewayTestCase.php
+++ b/tests/GatewayTestCase.php
@@ -248,7 +248,7 @@ class AlternativePaymentRequest extends PaymentRequest
 {
     public function authorize($data, Billable $billable = null)
     {
-        return new TestPaymentResponse([]);
+        return new AlternativePaymentResponse([]);
     }
 }
 

--- a/tests/Unit/TestPaymentGateway.php
+++ b/tests/Unit/TestPaymentGateway.php
@@ -8,7 +8,9 @@ use Payavel\Checkout\Models\PaymentMethod;
 use Payavel\Checkout\Models\PaymentTransaction;
 use Payavel\Checkout\Models\Wallet;
 use Payavel\Checkout\PaymentResponse;
+use Payavel\Checkout\Tests\AlternativePaymentResponse;
 use Payavel\Checkout\Tests\GatewayTestCase;
+use Payavel\Checkout\Tests\TestPaymentResponse;
 use Payavel\Checkout\Tests\User;
 
 class TestPaymentGateway extends GatewayTestCase
@@ -24,7 +26,7 @@ class TestPaymentGateway extends GatewayTestCase
     /** @test */
     public function setting_invalid_driver_throws_exception()
     {
-        config(['payment.defaults.driver' => 'fake']);
+        config(['payment.defaults.driver' => 'invalid']);
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Invalid checkout driver provided.');
@@ -38,7 +40,7 @@ class TestPaymentGateway extends GatewayTestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Invalid checkout provider.');
 
-        Payment::setProvider('fake');
+        Payment::setProvider('invalid');
     }
 
     /** @test */
@@ -47,7 +49,7 @@ class TestPaymentGateway extends GatewayTestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Invalid checkout merchant.');
 
-        Payment::setMerchant('faker');
+        Payment::setMerchant('invalid');
     }
 
     /** @test */
@@ -58,6 +60,18 @@ class TestPaymentGateway extends GatewayTestCase
 
         Payment::setProvider('alternative');
         Payment::authorize([]);
+    }
+
+    /** @test */
+    public function resetting_payment_service_to_default_configuration()
+    {
+        Payment::provider('alternative')->merchant('alternate');
+
+        $this->assertEquals(AlternativePaymentResponse::class, get_class(Payment::authorize([])));
+
+        Payment::reset();
+
+        $this->assertEquals(TestPaymentResponse::class, get_class(Payment::authorize([])));
     }
 
     /** @test */


### PR DESCRIPTION
### **What does this PR do?** :robot:
- Adds `reset()` to PaymentService::class`.

### **Does this relate to any issue?** :link:
Closes #28 
