### PR TITLE
[2.x] Prefer arrow functions over anonymous functions.

### DIFF
--- a/database/factories/PaymentMethodFactory.php
+++ b/database/factories/PaymentMethodFactory.php
@@ -37,17 +37,17 @@ class PaymentMethodFactory extends Factory
     {
         return $this->afterMaking(function (PaymentMethod $paymentMethod) {
             if(is_null($paymentMethod->wallet_id)) {
-                $wallet = Wallet::inRandomOrder()->firstOr(function () {
-                    return Wallet::factory()->create();
-                });
+                $wallet = Wallet::inRandomOrder()->firstOr(
+                    fn () => Wallet::factory()->create()
+                );
 
                 $paymentMethod->wallet_id = $wallet->id;
             }
 
             if (is_null($paymentMethod->type_id)) {
-                $type = PaymentType::inRandomOrder()->firstOr(function () {
-                    return PaymentType::factory()->create();
-                });
+                $type = PaymentType::inRandomOrder()->firstOr(
+                    fn () => PaymentType::factory()->create()
+                );
 
                 $paymentMethod->type_id = $type->id;
             }

--- a/database/factories/PaymentTransactionFactory.php
+++ b/database/factories/PaymentTransactionFactory.php
@@ -43,11 +43,12 @@ class PaymentTransactionFactory extends Factory
             if (is_null($transaction->provider_id)) {
                 $provider = ! is_null($transaction->payment_method_id)
                     ? $transaction->paymentMethod->provider
-                    : Provider::whereHas('accounts', function ($query) use ($transaction) {
-                        $query->where('payment_accounts.id', $transaction->account_id);
-                    })->inRandomOrder()->firstOr(function () {
-                        return Provider::factory()->create();
-                    });
+                    : Provider::whereHas(
+                        'accounts',
+                        fn ($query) => $query->where('payment_accounts.id', $transaction->account_id)
+                    )->inRandomOrder()->firstOr(
+                        fn () => Provider::factory()->create()
+                    );
 
                 $transaction->provider_id = $provider->id;
             }
@@ -55,9 +56,11 @@ class PaymentTransactionFactory extends Factory
             if (is_null($transaction->account_id)) {
                 $account = ! is_null($transaction->payment_method_id)
                     ? $transaction->paymentMethod->account
-                    : Account::whereHas('providers', function ($query) use ($transaction) {
-                        $query->where('payment_providers.id', $transaction->provider_id);
-                    })->inRandomOrder()->firstOr(function () use ($transaction) {
+                    : Account::whereHas(
+                        'providers',
+                        fn ($query) => $query->where('payment_providers.id', $transaction->provider_id)
+                    )->inRandomOrder()
+                    ->firstOr(function () use ($transaction) {
                         $account = Account::factory()->create();
 
                         $account->providers()->attach($transaction->provider_id, ['is_default' => true]);

--- a/database/factories/WalletFactory.php
+++ b/database/factories/WalletFactory.php
@@ -37,19 +37,23 @@ class WalletFactory extends Factory
     {
         return $this->afterMaking(function (Wallet $wallet) {
             if (is_null($wallet->provider_id)) {
-                $provider = Provider::whereHas('accounts', function ($query) use ($wallet) {
-                    $query->where('payment_accounts.id', $wallet->account_id);
-                })->inRandomOrder()->firstOr(function () {
-                    return Provider::factory()->create();
-                });
+                $provider = Provider::whereHas(
+                    'accounts',
+                    fn ($query) => $query->where('payment_accounts.id', $wallet->account_id)
+                )->inRandomOrder()
+                ->firstOr(
+                    fn () => Provider::factory()->create()
+                );
 
                 $wallet->provider_id = $provider->id;
             }
 
             if (is_null($wallet->account_id)) {
-                $account = Account::whereHas('providers', function ($query) use ($wallet) {
-                    $query->where('payment_providers.id', $wallet->provider_id);
-                })->inRandomOrder()->firstOr(function () use ($wallet) {
+                $account = Account::whereHas(
+                    'providers',
+                    fn ($query) => $query->where('payment_providers.id', $wallet->provider_id)
+                )->inRandomOrder()
+                ->firstOr(function () use ($wallet) {
                     $account = Account::factory()->create();
 
                     $account->providers()->attach($wallet->provider_id, ['is_default' => true]);

--- a/src/CheckoutServiceProvider.php
+++ b/src/CheckoutServiceProvider.php
@@ -23,9 +23,10 @@ class CheckoutServiceProvider extends ServiceProvider
 
     public function register()
     {
-        $this->app->singleton(CheckoutGateway::class, function ($app) {
-            return new CheckoutGateway();
-        });
+        $this->app->singleton(
+            CheckoutGateway::class,
+            fn ($app) => new CheckoutGateway()
+        );
 
         $this->mergeConfigFrom(
             __DIR__ . '/../config/checkout.php',

--- a/tests/Unit/BillableTraitTest.php
+++ b/tests/Unit/BillableTraitTest.php
@@ -25,9 +25,9 @@ class BillableTraitTest extends TestCase
 
         $this->assertCount($totalWallets, $billable->wallets);
 
-        $billable->wallets->each(function ($wallet) {
-            $this->assertTrue($wallet->isLocalModel);
-        });
+        $billable->wallets->each(
+            fn ($wallet) => $this->assertTrue($wallet->isLocalModel)
+        );
     }
 }
 


### PR DESCRIPTION
### **What does this PR do?** :robot:
- Replaces standard anonymous functions with arrow functions for single liner return statements.

### **Does this relate to any issue?** :link:
Closes #41
