### PR TITLE
[2.x] Fix foreign key mismatch in base checkout migration.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "test": "vendor/bin/phpunit"
     },
     "require": {
-        "payavel/orchestration": "dev-master"
+        "payavel/orchestration": "dev-bug-windows_directory_seperator"
     },
     "require-dev": {
         "orchestra/testbench": "^8.0|^9.0"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "test": "vendor/bin/phpunit"
     },
     "require": {
-        "payavel/orchestration": "dev-bug-windows_directory_seperator"
+        "payavel/orchestration": "dev-master"
     },
     "require-dev": {
         "orchestra/testbench": "^8.0|^9.0"

--- a/database/migrations/2024_01_01_000010_create_base_checkout_tables.php
+++ b/database/migrations/2024_01_01_000010_create_base_checkout_tables.php
@@ -62,8 +62,8 @@ return new class () extends Migration {
             $table->timestamps();
 
             if ($usingDatabaseDriver) {
-                $table->foreign('provider_id')->references('id')->on('providers')->onUpdate('cascade')->onDelete('set null');
-                $table->foreign('account_id')->references('id')->on('accounts')->onUpdate('cascade')->onDelete('set null');
+                $table->foreign('provider_id')->references('id')->on('providers')->onUpdate('cascade');
+                $table->foreign('account_id')->references('id')->on('accounts')->onUpdate('cascade');
             }
 
             $table->foreign('payment_method_id')->references('id')->on('payment_methods')->onDelete('set null');

--- a/tests/Feature/Console/Commands/TestCheckoutInstallCommand.php
+++ b/tests/Feature/Console/Commands/TestCheckoutInstallCommand.php
@@ -25,6 +25,7 @@ abstract class TestCheckoutInstallCommand extends TestCase implements CreatesSer
         $fakeGateway = $this->gatewayPath($this->checkoutService);
         $providerGateway = $this->gatewayPath($provider);
 
+        $ds = DIRECTORY_SEPARATOR;
         $this->artisan('checkout:install')
             ->expectsQuestion("Choose a driver for the {$this->checkoutService->getName()} service.", Config::get('orchestration.defaults.driver'))
             ->expectsQuestion("How should the {$this->checkoutService->getName()} provider be named?", $provider->getName())
@@ -33,14 +34,14 @@ abstract class TestCheckoutInstallCommand extends TestCase implements CreatesSer
             ->expectsQuestion("How should the {$this->checkoutService->getName()} account be named?", $account->getName())
             ->expectsQuestion("How should the {$this->checkoutService->getName()} account be identified?", $account->getId())
             ->expectsConfirmation("Would you like to add another {$this->checkoutService->getName()} account?", 'no')
-            ->expectsOutputToContain("Config [config/{$checkoutServiceConfig->orchestration}] created successfully.")
-            ->expectsOutputToContain("Config [config/{$checkoutServiceConfig->service}] created successfully.")
-            ->expectsOutputToContain("Contract [app/{$checkoutServiceContract->requester}] created successfully.")
-            ->expectsOutputToContain("Contract [app/{$checkoutServiceContract->responder}] created successfully.")
-            ->expectsOutputToContain("Gateway [app/{$fakeGateway->request}] created successfully.")
-            ->expectsOutputToContain("Gateway [app/{$fakeGateway->response}] created successfully.")
-            ->expectsOutputToContain("Gateway [app/{$providerGateway->request}] created successfully.")
-            ->expectsOutputToContain("Gateway [app/{$providerGateway->response}] created successfully.")
+            ->expectsOutputToContain("Config [config{$ds}{$checkoutServiceConfig->orchestration}] created successfully.")
+            ->expectsOutputToContain("Config [config{$ds}{$checkoutServiceConfig->service}] created successfully.")
+            ->expectsOutputToContain("Contract [app{$ds}{$checkoutServiceContract->requester}] created successfully.")
+            ->expectsOutputToContain("Contract [app{$ds}{$checkoutServiceContract->responder}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$fakeGateway->request}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$fakeGateway->response}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$providerGateway->request}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$providerGateway->response}] created successfully.")
             ->assertSuccessful();
 
         $config = require(config_path($checkoutServiceConfig->service));

--- a/tests/Feature/Console/Commands/TestCheckoutProviderCommand.php
+++ b/tests/Feature/Console/Commands/TestCheckoutProviderCommand.php
@@ -18,12 +18,13 @@ abstract class TestCheckoutProviderCommand extends TestCase implements CreatesSe
 
         $gateway = $this->gatewayPath($provider);
 
+        $ds = DIRECTORY_SEPARATOR;
         $this->artisan('checkout:provider', [
             'provider' => $provider->getName(),
             '--id' => $provider->getId(),
         ])
-            ->expectsOutputToContain("Gateway [app/{$gateway->request}] created successfully.")
-            ->expectsOutputToContain("Gateway [app/{$gateway->response}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$gateway->request}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$gateway->response}] created successfully.")
             ->assertSuccessful();
 
         $this->assertGatewayExists($provider);


### PR DESCRIPTION
### **What does this PR do?** :robot:
Fixes the foreign key mismatch with the base orchestration tables when using the database driver for a service.

### **How should this be tested?** :microscope:
Run `php artisan checkout:install`, choose the database driver & run `php artisan migrate`. No error should be thrown anymore.

### **Any background context you would like to provide?** :construction:
https://github.com/payavel/orchestration/pull/66 fixes the first point of #53, and this PR fixes the second point.

### **Does this relate to any issue?** :link:
Closes #53 and relates to https://github.com/payavel/orchestration/pull/66.
