### PR TITLE
[2.x] Fix factory suppositions

### DIFF
--- a/src/CheckoutServiceProvider.php
+++ b/src/CheckoutServiceProvider.php
@@ -2,14 +2,9 @@
 
 namespace Payavel\Checkout;
 
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\ServiceProvider;
 use Payavel\Checkout\Console\Commands\CheckoutInstall;
 use Payavel\Checkout\Console\Commands\CheckoutProvider;
-use Payavel\Checkout\Models\Dispute;
-use Payavel\Checkout\Models\Payment;
-use Payavel\Checkout\Models\Refund;
-use Payavel\Orchestration\Support\ServiceConfig;
 
 class CheckoutServiceProvider extends ServiceProvider
 {
@@ -24,12 +19,6 @@ class CheckoutServiceProvider extends ServiceProvider
         $this->registerCommands();
 
         $this->registerMigrations();
-
-        Relation::morphMap([
-            Payment::class => fn () => ServiceConfig::get('checkout', 'models.' . Payment::class, Payment::class),
-            Refund::class => fn () => ServiceConfig::get('checkout', 'models.' . Refund::class, Refund::class),
-            Dispute::class => fn () => ServiceConfig::get('checkout', 'models.' . Dispute::class, Dispute::class),
-        ]);
     }
 
     public function register()

--- a/src/Models/TransactionEvent.php
+++ b/src/Models/TransactionEvent.php
@@ -3,8 +3,6 @@
 namespace Payavel\Checkout\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Arr;
 use Payavel\Orchestration\Support\ServiceConfig;
 use Payavel\Orchestration\Traits\HasFactory;
 

--- a/src/Models/TransactionEvent.php
+++ b/src/Models/TransactionEvent.php
@@ -66,21 +66,4 @@ class TransactionEvent extends Model
     {
         return $this->morphTo();
     }
-
-    /**
-     * Retrieve the actual class name for a given morph class.
-     *
-     * @param  string  $class
-     * @return string
-     */
-    public static function getActualClassNameForMorph($class)
-    {
-        $value = Arr::get(Relation::morphMap() ?: [], $class, $class);
-
-        if (is_callable($value)) {
-            return $value();
-        }
-
-        return $value;
-    }
 }

--- a/tests/Unit/PaymentModelTest.php
+++ b/tests/Unit/PaymentModelTest.php
@@ -2,6 +2,7 @@
 
 namespace Payavel\Checkout\Tests\Unit;
 
+use Payavel\Checkout\CheckoutStatus;
 use Payavel\Checkout\Models\Payment;
 use Payavel\Checkout\Models\PaymentInstrument;
 use Payavel\Checkout\Models\PaymentRail;
@@ -72,12 +73,12 @@ class PaymentModelTest extends TestCase
         $payment = Payment::factory()->create();
         $this->assertEmpty($payment->events);
 
-        $paymentWith2Events = Payment::factory()->hasEvents(2)->create();
+        $paymentWith2Events = Payment::factory()->hasEvents(2, ['status_code' => CheckoutStatus::AUTHORIZED])->create();
         $this->assertCount(2, $paymentWith2Events->events);
         $this->assertContainsOnlyInstancesOf(TransactionEvent::class, $paymentWith2Events->events);
 
         ServiceConfig::set('checkout', 'models.' . TransactionEvent::class, TestTransactionEvent::class);
-        $paymentWith3OverriddenEvents = Payment::factory()->hasEvents(3)->create();
+        $paymentWith3OverriddenEvents = Payment::factory()->hasEvents(3, ['status_code' => CheckoutStatus::AUTHORIZED])->create();
         $this->assertCount(3, $paymentWith3OverriddenEvents->events);
         $this->assertContainsOnlyInstancesOf(TestTransactionEvent::class, $paymentWith3OverriddenEvents->events);
     }

--- a/tests/Unit/TransactionEventModelTest.php
+++ b/tests/Unit/TransactionEventModelTest.php
@@ -2,13 +2,10 @@
 
 namespace Payavel\Checkout\Tests\Unit;
 
-use Payavel\Checkout\Models\Dispute;
+use Payavel\Checkout\CheckoutStatus;
 use Payavel\Checkout\Models\Payment;
-use Payavel\Checkout\Models\Refund;
 use Payavel\Checkout\Models\TransactionEvent;
-use Payavel\Checkout\Tests\Models\TestDispute;
 use Payavel\Checkout\Tests\Models\TestPayment;
-use Payavel\Checkout\Tests\Models\TestRefund;
 use Payavel\Checkout\Tests\TestCase;
 use Payavel\Orchestration\Support\ServiceConfig;
 use PHPUnit\Framework\Attributes\Test;
@@ -18,33 +15,26 @@ class TransactionEventModelTest extends TestCase
     #[Test]
     public function retrieve_transaction_event_payment()
     {
-        $transactionEventWithPayment = TransactionEvent::factory()->create();
+        $transactionEventWithPayment = TransactionEvent::factory()->create(['status_code' => CheckoutStatus::AUTHORIZED]);
         $this->assertInstanceOf(Payment::class, $transactionEventWithPayment->payment);
 
         ServiceConfig::set('checkout', 'models.' . Payment::class, TestPayment::class);
-        $transactionEventWithOverriddenPayment = TransactionEvent::factory()->create();
+        $transactionEventWithOverriddenPayment = TransactionEvent::factory()->create(['status_code' => CheckoutStatus::AUTHORIZED]);
         $this->assertInstanceOf(TestPayment::class, $transactionEventWithOverriddenPayment->payment);
     }
 
     #[Test]
     public function retrieve_transaction_event_transactionable()
     {
-        $transactionEvent = TransactionEvent::factory()->create();
+        $transactionEvent = TransactionEvent::factory()->create(['status_code' => CheckoutStatus::AUTHORIZED]);
         $this->assertNull($transactionEvent->transactionable);
 
-        $transactionables = [
-            Payment::class => TestPayment::class,
-            Refund::class => TestRefund::class,
-            Dispute::class => TestDispute::class,
-        ];
+        $transactionEventWithTransactionable = TransactionEvent::factory()->for(Payment::factory(), 'transactionable')->create(['status_code' => CheckoutStatus::AUTHORIZED]);
+        $this->assertInstanceOf(Payment::class, $transactionEventWithTransactionable->transactionable);
 
-        $randomTransactionable = $this->faker->randomElement(array_keys($transactionables));
-        $transactionEventWithTransactionable = TransactionEvent::factory()->for($randomTransactionable::factory(), 'transactionable')->create();
-        $this->assertInstanceOf($randomTransactionable, $transactionEventWithTransactionable->transactionable);
-
-        $randomTransactionable = $this->faker->randomElement(array_keys($transactionables));
-        ServiceConfig::set('checkout', 'models.' . $randomTransactionable, $transactionables[$randomTransactionable]);
-        $transactionEventWithOverriddenTransactionable = TransactionEvent::factory()->for($transactionables[$randomTransactionable]::factory(), 'transactionable')->create();
-        $this->assertInstanceOf($transactionables[$randomTransactionable], $transactionEventWithOverriddenTransactionable->transactionable);
+        ServiceConfig::set('checkout', 'models.' . Payment::class, TestPayment::class);
+        $transactionEventWithOverriddenTransactionable = TransactionEvent::factory()->create(['status_code' => CheckoutStatus::AUTHORIZED]);
+        $transactionEventWithOverriddenTransactionable->transactionable()->associate(transform(Payment::factory()->create(), fn ($payment) => TestPayment::find($payment->id)));
+        $this->assertInstanceOf(TestPayment::class, $transactionEventWithOverriddenTransactionable->transactionable);
     }
 }


### PR DESCRIPTION
### **What does this PR do?** :robot:
Removes all model overriding capabilities from factories.

### **Any background context you would like to provide?** :construction:
Factories are not intended to be extended to the end user if they wish to override their models. They should also choose to override their factories.

### **Does this relate to any issue?** :link:
Closes #59 
